### PR TITLE
Add distributed testing with pytest-xdist for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,33 +32,8 @@ jobs:
     - name: Run linting
       run: make lint
 
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.13'
-        
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-      with:
-        enable-cache: true
-        cache-dependency-glob: "uv.lock"
-        
-    - name: Install dependencies
-      run: uv sync
-      
-    - name: Run unit tests
-      run: make test-unit
-
-  integration-tests:
-    name: Integration Tests
+  tests:
+    name: All Tests (Distributed)
     runs-on: ubuntu-latest
     
     steps:
@@ -82,5 +57,5 @@ jobs:
     - name: Install Playwright browsers
       run: uv run playwright install --with-deps
       
-    - name: Run integration tests
-      run: make test-integration
+    - name: Run all tests (distributed)
+      run: make test-dist

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ test-with-coverage: # Run tests with coverage
 	@echo "Running tests with coverage.."
 	uv run pytest --cov=. --cov-report=html --cov-report=term tests/
 
+test-dist: # Run tests distributed across CPUs
+	@echo "Running distributed tests.."
+	uv run pytest -n auto tests/
+
 # -----------------------------------------------------------
 # CAUTION: If you have a file with the same name as make
 # command, you need to add it to .PHONY below, otherwise it

--- a/README.md
+++ b/README.md
@@ -65,4 +65,9 @@ The filename format `invoice-data-<M-D>.txt` automatically generates:
 - `make generate CLIENT=<name> DATA=<file>` - Generate invoice
 - `make update` - Update dependencies
 - `make lint` - Run linters (isort, black, pyright, pylint)
+- `make test` - Run all tests
+- `make test-unit` - Run unit tests only
+- `make test-integration` - Run integration tests only
+- `make test-dist` - Run tests distributed across CPU cores (faster)
+- `make test-with-coverage` - Run tests with coverage reporting
 - `make help` - Show available commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
     "pytest-playwright>=0.7.0",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.12.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -164,6 +164,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "fonttools"
 version = "4.58.5"
 source = { registry = "https://pypi.org/simple" }
@@ -228,6 +237,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-playwright" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -245,6 +255,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-playwright", specifier = ">=0.7.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.12.3" },
 ]
 
@@ -569,6 +580,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/47/38e292ad92134a00ea05e6fc4fc44577baaa38b0922ab7ea56312b7a6663/pytest_playwright-0.7.0.tar.gz", hash = "sha256:b3f2ea514bbead96d26376fac182f68dcd6571e7cb41680a89ff1673c05d60b6", size = 16666, upload-time = "2025-01-31T11:06:05.453Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/96/5f8a4545d783674f3de33f0ebc4db16cc76ce77a4c404d284f43f09125e3/pytest_playwright-0.7.0-py3-none-any.whl", hash = "sha256:2516d0871fa606634bfe32afbcc0342d68da2dbff97fe3459849e9c428486da2", size = 16618, upload-time = "2025-01-31T11:06:08.075Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add pytest-xdist dependency for parallel test execution across CPU cores
- Add `test-dist` make command that runs `pytest -n auto tests/`
- Update GitHub Actions CI to use distributed testing approach
- Consolidate separate unit/integration test jobs into single distributed job

## Performance Impact
- Local testing shows ~42% performance improvement (18.42s → 10.73s)
- Should provide similar speedup in GitHub Actions CI
- Lower CI costs due to reduced runtime

## Test Results
```
# Regular tests
============================= 91 passed in 18.42s ==============================

# Distributed tests  
created: 4/4 workers
============================= 91 passed in 10.73s ==============================
```

🤖 Generated with [Claude Code](https://claude.ai/code)